### PR TITLE
feature/#23-sharing-remotedb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,6 @@
 version: "3.1"
 
 services:
-  db:
-    image: mysql
-    restart: always
-    env_file: ./server/.env
-    networks:
-      - compose-networks
-    ports:
-      - "3307:3307"
-    expose:
-      - 3307
-
   admin-web:
     build: 
       context: ./client
@@ -19,8 +8,6 @@ services:
     restart: always
     ports:
       - "3000:3000"
-    depends_on:
-      - db
     networks:
       - compose-networks
 
@@ -31,8 +18,6 @@ services:
     restart: always
     ports:
       - "3001:8080"
-    depends_on:
-      - db
     volumes:
       - /var/lib/admin
     networks:


### PR DESCRIPTION
## What?
- issue #23 

## Why?
- 기존 서비스와의 DB 떄문에

## How?
- aacp-db를 heroku cleardb로 배포
- admin-api의 env를 remote db info로 변경

## Testing?
O

## Screenshots (optional)
X


## Anything Else?
X 


## Reviewers
@