### PR TITLE
Feat#16 table crud interface

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.6.2",
     "axios": "^0.24.0",
     "classnames": "^2.3.1",
     "node-sass": "5.0.0",
@@ -10,11 +11,12 @@
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.20.4",
     "react-icons": "^4.3.1",
+    "react-redux": "^7.2.6",
     "react-router-dom": "^6.0.2",
     "react-scripts": "4.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "export PORT=4000 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,7 @@
-import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import Login from "./pages/Login";
-import DataBases from "./pages/AllDataBases";
+import AllDataBases from "./pages/AllDataBases";
+import InsideDataBase from "./pages/InsideDataBase";
 
 function App() {
   const isAuthorized = localStorage.getItem("isAuthorized");
@@ -14,7 +15,8 @@ function App() {
       )} */}
       <Routes>
         <Route path="/login" element={<Login />} />
-        <Route path="/" element={<DataBases />} />
+        <Route exact path="/" element={<AllDataBases />} />
+        <Route path="/:dbName" element={<InsideDataBase />} />
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,4 +1,6 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "./store";
 import Login from "./pages/Login";
 import AllDataBases from "./pages/AllDataBases";
 import InsideDataBase from "./pages/InsideDataBase";
@@ -7,18 +9,20 @@ function App() {
   const isAuthorized = localStorage.getItem("isAuthorized");
 
   return (
-    <BrowserRouter>
-      {/* {!isAuthorized ? (
+    <Provider store={store}>
+      <BrowserRouter>
+        {/* {!isAuthorized ? (
         <Navigate replace to="/login" />
       ) : (
         <Navigate replace to="/" />
       )} */}
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route exact path="/" element={<AllDataBases />} />
-        <Route path="/:dbName" element={<InsideDataBase />} />
-      </Routes>
-    </BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route exact path="/" element={<AllDataBases />} />
+          <Route path="/:dbName" element={<InsideDataBase />} />
+        </Routes>
+      </BrowserRouter>
+    </Provider>
   );
 }
 

--- a/client/src/__mocks/TableMocks.js
+++ b/client/src/__mocks/TableMocks.js
@@ -1,0 +1,29 @@
+const tables = [
+  {
+    id: 1,
+    title: "user",
+    name: "name",
+  },
+  {
+    id: 2,
+    title: "course",
+  },
+  {
+    id: 3,
+    title: "courseDate",
+  },
+  {
+    id: 4,
+    title: "member",
+  },
+  {
+    id: 5,
+    title: "memberList",
+  },
+  {
+    id: 6,
+    title: "admin",
+  },
+];
+
+export default tables;

--- a/client/src/__mocks/TableMocks.js
+++ b/client/src/__mocks/TableMocks.js
@@ -2,7 +2,6 @@ const tables = [
   {
     id: 1,
     title: "user",
-    name: "name",
   },
   {
     id: 2,

--- a/client/src/common/axios.js
+++ b/client/src/common/axios.js
@@ -4,5 +4,7 @@ export default axios.create({
   baseURL: "http://localhost:4000/",
   headers: {
     "Content-type": "application/json",
+    "x-access-token": localStorage.getItem("x-access-token") || "",
+    "x-refresh-token": localStorage.getItem("x-refresh-token") || "",
   },
 });

--- a/client/src/components/AddTable/ColumnElement/index.jsx
+++ b/client/src/components/AddTable/ColumnElement/index.jsx
@@ -1,0 +1,125 @@
+/* eslint-disable no-param-reassign */
+import React, { useContext, useState, useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+import { GiCancel } from "react-icons/gi";
+import cx from "classnames";
+import "./style.scss";
+
+export default function ColumnElement({ element, remove }) {
+  const tables = useSelector(state => state.table.tables);
+  const [isDisabled, setDisabled] = useState(false);
+
+  function pkSelect(isPK) {
+    element.PK = isPK.target.value;
+    console.log(element);
+    setDisabled(!isDisabled);
+    if (isPK.target.value) {
+      element.FK = false;
+      element.constraint = false;
+      document.getElementById(`fkId${element.id}`).value = false;
+      document.getElementById(`conId${element.id}`).value = false;
+    }
+  }
+
+  return (
+    <div className="columnBox">
+      <form className="column">
+        <div className="element">
+          <span className="label"># 컬럼명: </span>
+          <input
+            className="input"
+            type="text"
+            placeholder="컬럼 명 입력."
+            onChange={e => {
+              element.columnName = e.target.value;
+            }}
+          />
+        </div>
+
+        <div className="element">
+          <span className="label">타입: </span>
+          <select
+            className="select"
+            id={`dataId${element.id}`}
+            name="data"
+            defaultValue="int"
+            onChange={e => {
+              element.dataType = e.target.value;
+            }}>
+            <option value="int">INT</option>
+            <option value="char">CHAR</option>
+            <option value="date">DATE</option>
+          </select>
+        </div>
+
+        <div className="element">
+          <span className="label">제약조건: </span>
+          <select
+            className="select"
+            id={`conId${element.id}`}
+            name="constraint"
+            defaultValue="false"
+            onChange={e => {
+              element.constraint = e.target.value;
+            }}>
+            <option value="false">X</option>
+            <option value="NOT NULL" disabled={isDisabled}>
+              NOT NULL
+            </option>
+            <option value="UNIQUE" disabled={isDisabled}>
+              UNIQUE
+            </option>
+          </select>
+        </div>
+
+        <div className="element">
+          <span className="label">DEFAULT값: </span>
+          <input
+            className="input"
+            type="text"
+            placeholder="기본 값 입력."
+            onChange={e => {
+              element.default = e.target.value;
+            }}
+          />
+        </div>
+
+        <div className="element">
+          <span className="label">PK: </span>
+          <select
+            className="select"
+            id={`pkId${element.id}`}
+            name="PK"
+            onChange={pkSelect}
+            defaultValue="false">
+            <option value="true">O</option>
+            <option value="false">X</option>
+          </select>
+        </div>
+
+        <div className="element">
+          <span className="label">FK: </span>
+          <select
+            className="select"
+            id={`fkId${element.id}`}
+            name="FK"
+            defaultValue="false"
+            onChange={e => {
+              element.FK = e.target.value;
+            }}>
+            <option value="false">X</option>
+            {tables.map(table => (
+              <option
+                key={`${table.title}option`}
+                disabled={isDisabled}
+                value={table.title}>
+                {table.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      </form>
+      <GiCancel className="cancel" onClick={() => remove(element.id)} />
+    </div>
+  );
+}

--- a/client/src/components/AddTable/ColumnElement/index.jsx
+++ b/client/src/components/AddTable/ColumnElement/index.jsx
@@ -10,8 +10,7 @@ export default function ColumnElement({ element, remove }) {
   const [isDisabled, setDisabled] = useState(false);
 
   function pkSelect(isPK) {
-    element.PK = isPK.target.value;
-    console.log(element);
+    element.PK = Boolean(isPK.target.value);
     setDisabled(!isDisabled);
     if (isPK.target.value) {
       element.FK = false;

--- a/client/src/components/AddTable/ColumnElement/style.scss
+++ b/client/src/components/AddTable/ColumnElement/style.scss
@@ -1,0 +1,32 @@
+@import "../../../style/color.scss";
+.columnBox {
+  display: flex;
+  flex-direction: row;
+  margin: 15px 0 0 0;
+  .cancel {
+    margin: auto auto auto 10px;
+    font-size: 20px;
+    &:hover {
+      cursor: pointer;
+    }
+  }
+  .column {
+    background-color: $primary;
+    border-radius: 4px;
+    padding: 5px;
+
+    .element {
+      display: inline;
+      margin: 0 5px 0 0;
+      &:last-child {
+        margin-right: 0;
+      }
+      .input {
+        margin-left: 0;
+      }
+      .label {
+        font-size: 14px;
+      }
+    }
+  }
+}

--- a/client/src/components/AddTable/index.jsx
+++ b/client/src/components/AddTable/index.jsx
@@ -1,0 +1,82 @@
+import React, { useContext, useState, useEffect, useRef } from "react";
+import cx from "classnames";
+import "./style.scss";
+import ColumnElement from "./ColumnElement";
+
+export default function AddTable() {
+  const [tableName, setTableName] = useState("");
+  const [columns, setColumns] = useState([]);
+  const nextId = useRef(1);
+
+  let isNullColumnName = true;
+
+  const removeColumn = remove => {
+    setColumns(columns.filter(column => column.id !== remove));
+  };
+
+  const handleSubmitColumn = () => {
+    columns.forEach(column => {
+      if (column.columnName.length === 0) {
+        isNullColumnName = true;
+        return;
+      }
+      if (column.columnName.length !== 0) isNullColumnName = false;
+    });
+    if (tableName.length >= 1 && !isNullColumnName)
+      console.log({ tableName, ...columns });
+  };
+
+  const initialState = {
+    columnName: "",
+    dataType: "",
+    constraint: false,
+    default: "",
+    PK: false,
+    FK: false,
+  };
+
+  return (
+    <div className="addContainer">
+      <div className="tableInputBox">
+        <span className="tableLabel">테이블 이름: </span>
+        <input
+          className="input tableInput"
+          type="text"
+          placeholder="테이블 명 입력."
+          value={tableName}
+          onChange={e => {
+            setTableName(e.target.value);
+          }}
+        />
+        <button
+          className="addBox"
+          type="button"
+          onClick={() => {
+            setColumns([...columns, { id: nextId.current, ...initialState }]);
+            nextId.current += 1;
+          }}>
+          <div className="addCircle" />
+          <span className="addText">컬럼 추가</span>
+        </button>
+      </div>
+
+      <ul>
+        {columns.map(column => (
+          <ColumnElement
+            key={column.id + column}
+            element={column}
+            remove={removeColumn}
+          />
+        ))}
+      </ul>
+
+      <button
+        className="addBox table"
+        type="button"
+        onClick={handleSubmitColumn}>
+        <div className="addCircle table" />
+        <span className="addText">테이블 추가</span>
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/AddTable/index.jsx
+++ b/client/src/components/AddTable/index.jsx
@@ -28,7 +28,7 @@ export default function AddTable() {
 
   const initialState = {
     columnName: "",
-    dataType: "",
+    dataType: "CHAR",
     constraint: false,
     default: "",
     PK: false,

--- a/client/src/components/AddTable/style.scss
+++ b/client/src/components/AddTable/style.scss
@@ -1,0 +1,75 @@
+@import "../../style/color.scss";
+.addContainer {
+  display: flex;
+  flex-direction: column;
+  min-width: 840px;
+  height: fit-content;
+  background-color: $white;
+  box-shadow: $box-shadow;
+  border-radius: 10px;
+  margin: 200px auto;
+  padding: 20px;
+  font-weight: bold;
+  .addBox {
+    display: flex;
+    flex-direction: row;
+    background-color: $white;
+    border: none;
+    outline: none;
+    cursor: pointer;
+    margin: 0 0 0 auto;
+    padding: 0;
+    .addCircle {
+      width: 20px;
+      height: 20px;
+      background-color: $adding;
+      border-radius: 50%;
+      margin: auto 5px auto 0;
+    }
+    .table {
+      background-color: $create;
+    }
+    .addText {
+      margin: auto 0;
+      font-weight: bold;
+      font-size: 17px;
+    }
+  }
+  .table {
+    margin-top: 15px;
+  }
+  .tableInputBox {
+    display: flex;
+    flex-direction: row;
+    .tableLabel {
+      margin: auto 0;
+    }
+  }
+  .select,
+  .input {
+    display: inline;
+    border: 2px solid $black;
+    border-radius: 4px;
+    margin: auto 0;
+    color: $black;
+    font-size: 15px;
+    font-weight: bold;
+    &:focus {
+      outline: none;
+    }
+    &::placeholder {
+      color: $black;
+      font-size: 13px;
+    }
+    &::-ms-input-placeholder {
+      color: $black;
+      font-size: 13px;
+    }
+  }
+  .input {
+    max-width: 80px;
+  }
+  .tableInput {
+    margin-left: 11px;
+  }
+}

--- a/client/src/components/DbCardList/DbCard/index.jsx
+++ b/client/src/components/DbCardList/DbCard/index.jsx
@@ -1,13 +1,16 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import React, { useState, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import cx from "classnames";
-import http from "../../../common/http";
+import http from "../../../common/axios";
 import "./style.scss";
 
 export default function DataBase({ isNew, database, id, remove, add }) {
   const [dbName, setDbName] = useState("");
   const [msgState, setMsgState] = useState("");
   const [isAddClick, setIsAddClick] = useState(false);
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (isNew && !isAddClick) {
@@ -25,6 +28,10 @@ export default function DataBase({ isNew, database, id, remove, add }) {
   const handleInputChange = event => {
     const { value } = event.target;
     setDbName(value);
+  };
+
+  const handleClick = dbName => {
+    if (!isAddClick) navigate(`/${dbName}`);
   };
 
   return (
@@ -66,7 +73,12 @@ export default function DataBase({ isNew, database, id, remove, add }) {
           </div>
         </>
       ) : (
-        <span className="cardText">{dbName}</span>
+        <span
+          className="cardText"
+          onClick={() => handleClick(dbName)}
+          aria-hidden="true">
+          {dbName}
+        </span>
       )}
     </div>
   );

--- a/client/src/components/DbCardList/index.jsx
+++ b/client/src/components/DbCardList/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import cx from "classnames";
 import DataBasesMocks from "../../__mocks/DataBasesMocks";
 import DataBase from "./DbCard";
-import http from "../../common/http";
+import http from "../../common/axios";
 import "./style.scss";
 
 export default function DataBases() {

--- a/client/src/components/LoginForm/index.jsx
+++ b/client/src/components/LoginForm/index.jsx
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 import { AiOutlineLock, AiOutlineUnlock } from "react-icons/ai";
 import { IoPersonOutline } from "react-icons/io5";
 import cx from "classnames";
-import http from "../../common/http";
+import http from "../../common/axios";
 import "./style.scss";
 
 export default function LoginForm() {

--- a/client/src/components/Navigation/index.jsx
+++ b/client/src/components/Navigation/index.jsx
@@ -1,15 +1,32 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
 import cx from "classnames";
 import "./style.scss";
-import TableMocks from "../../__mocks/TableMocks";
+import { AiOutlineDatabase } from "react-icons/ai";
+import { useDispatch, useSelector } from "react-redux";
+import { add } from "../../store/tableSlice";
 
 export default function Natigation() {
+  const dispatch = useDispatch();
+  const tables = useSelector(state => state.table.tables);
+
+  console.log(tables);
   return (
     <nav className="navigation">
+      <button
+        type="button"
+        className="addTable"
+        onClick={() => {
+          dispatch(add(true));
+        }}>
+        <AiOutlineDatabase />
+        <p className="addText">테이블 추가</p>
+      </button>
       <p className="naviTitle">테이블 목록</p>
       <ul className="sideMenu">
-        {TableMocks.map(table => (
-          <li className="tableTitle">{table.title}</li>
+        {tables.map(table => (
+          <li key={table.id + table.title} className="tableTitle">
+            {table.title}
+          </li>
         ))}
       </ul>
     </nav>

--- a/client/src/components/Navigation/index.jsx
+++ b/client/src/components/Navigation/index.jsx
@@ -1,0 +1,17 @@
+import React, { useContext, useState, useEffect, useRef } from "react";
+import cx from "classnames";
+import "./style.scss";
+import TableMocks from "../../__mocks/TableMocks";
+
+export default function Natigation() {
+  return (
+    <nav className="navigation">
+      <p className="naviTitle">테이블 목록</p>
+      <ul className="sideMenu">
+        {TableMocks.map(table => (
+          <li className="tableTitle">{table.title}</li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/client/src/components/Navigation/style.scss
+++ b/client/src/components/Navigation/style.scss
@@ -1,0 +1,35 @@
+@import "../../style/color.scss";
+.navigation {
+  display: block;
+  left: 0;
+  width: 200px;
+  min-height: calc(100vh - 101px);
+  height: fit-content;
+  z-index: 5;
+  background-color: $white;
+  border-right: 1px solid $gray400;
+  word-break: break-all;
+  .naviTitle {
+    margin: 30px auto -10px 20px;
+    font-size: 25px;
+    font-weight: bold;
+  }
+  .sideMenu {
+    height: fit-content;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 30px;
+    .tableTitle {
+      margin: 30px auto 0 30px;
+      color: $gray600;
+      font-size: 20px;
+      font-weight: 500;
+      &:hover {
+        color: $primary;
+        font-weight: bolder;
+        cursor: pointer;
+      }
+    }
+  }
+}

--- a/client/src/components/Navigation/style.scss
+++ b/client/src/components/Navigation/style.scss
@@ -3,12 +3,26 @@
   display: block;
   left: 0;
   width: 200px;
-  min-height: calc(100vh - 101px);
-  height: fit-content;
+  min-height: calc(100vh - 152px);
   z-index: 5;
   background-color: $white;
   border-right: 1px solid $gray400;
   word-break: break-all;
+  .addTable {
+    display: flex;
+    flex-direction: row;
+    margin: 30px auto -10px 20px;
+    background-color: $white;
+    border: none;
+    outline: none;
+    padding: 0;
+    cursor: pointer;
+    font-size: 26px;
+    font-weight: bold;
+    &:hover {
+      color: $create;
+    }
+  }
   .naviTitle {
     margin: 30px auto -10px 20px;
     font-size: 25px;
@@ -16,7 +30,6 @@
   }
   .sideMenu {
     height: fit-content;
-    height: 100%;
     display: flex;
     flex-direction: column;
     margin-bottom: 30px;

--- a/client/src/pages/InsideDataBase/index.jsx
+++ b/client/src/pages/InsideDataBase/index.jsx
@@ -1,22 +1,33 @@
 import { useState, useEffect } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import "./style.scss";
+import { useDispatch } from "react-redux";
 import Navigation from "../../components/Navigation";
+import AddTable from "../../components/AddTable";
+import TableMocks from "../../__mocks/TableMocks";
+import { getTables } from "../../store/tableSlice";
 
 export default function InsideDataBase(props) {
   const { dbName } = useParams();
+  const dispatch = useDispatch();
 
-  //   useEffect(() => {}, [dbName]); api 연결
+  useEffect(() => {
+    dispatch(getTables(TableMocks));
+  }, [dbName]);
 
   return (
     <div className="mainPage">
-      <div className="titleBox">
+      <header className="titleBox">
         <div className="title">
           <span className="dbName">{dbName}</span>
           <span>내부 조회</span>
         </div>
-      </div>
-      <Navigation />
+      </header>
+      <section className="buttonBar"></section>
+      <main className="mainContent">
+        <Navigation />
+        <AddTable />
+      </main>
     </div>
   );
 }

--- a/client/src/pages/InsideDataBase/index.jsx
+++ b/client/src/pages/InsideDataBase/index.jsx
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+import { Navigate, useParams } from "react-router-dom";
+import "./style.scss";
+import Navigation from "../../components/Navigation";
+
+export default function InsideDataBase(props) {
+  const { dbName } = useParams();
+
+  //   useEffect(() => {}, [dbName]); api 연결
+
+  return (
+    <div className="mainPage">
+      <div className="titleBox">
+        <div className="title">
+          <span className="dbName">{dbName}</span>
+          <span>내부 조회</span>
+        </div>
+      </div>
+      <Navigation />
+    </div>
+  );
+}

--- a/client/src/pages/InsideDataBase/style.scss
+++ b/client/src/pages/InsideDataBase/style.scss
@@ -1,6 +1,6 @@
 @import "../../style/color.scss";
 .mainPage {
-  position: relative;
+  // position: relative;
   display: flex;
   flex-direction: column;
   .titleBox {
@@ -19,5 +19,14 @@
         margin-right: 10px;
       }
     }
+  }
+  .buttonBar {
+    height: 50px;
+    background-color: $white;
+    border-bottom: 1px solid $gray400;
+  }
+  .mainContent {
+    display: flex;
+    flex-direction: row;
   }
 }

--- a/client/src/pages/InsideDataBase/style.scss
+++ b/client/src/pages/InsideDataBase/style.scss
@@ -1,0 +1,23 @@
+@import "../../style/color.scss";
+.mainPage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  .titleBox {
+    display: flex;
+    flex-direction: column;
+    height: 100px;
+    background-color: $white;
+    border-bottom: 1px solid $gray400;
+    font-size: 40px;
+    font-weight: bold;
+    color: $black;
+    .title {
+      margin: auto;
+      .dbName {
+        color: $primary;
+        margin-right: 10px;
+      }
+    }
+  }
+}

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1,8 +1,11 @@
 import { configureStore, MiddlewareArray } from "@reduxjs/toolkit";
 import logger from "./loggerMiddleware";
+import { tableSlice } from "./tableSlice";
 
 export const store = configureStore({
-  reducer: {},
+  reducer: {
+    table: tableSlice.reducer,
+  },
   middleware: new MiddlewareArray().concat(logger),
   devTools: process.env.NODE_ENV !== "production",
 });

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -1,0 +1,8 @@
+import { configureStore, MiddlewareArray } from "@reduxjs/toolkit";
+import logger from "./loggerMiddleware";
+
+export const store = configureStore({
+  reducer: {},
+  middleware: new MiddlewareArray().concat(logger),
+  devTools: process.env.NODE_ENV !== "production",
+});

--- a/client/src/store/loggerMiddleware.js
+++ b/client/src/store/loggerMiddleware.js
@@ -1,0 +1,9 @@
+const loggerMiddleware = store => next => action => {
+  console.log("PREV STATE:", store.getState());
+  console.log("action:", action);
+  const result = next(action);
+  console.log("NEXT STATE:", store.getState());
+  return result;
+};
+
+export default loggerMiddleware;

--- a/client/src/store/tableSlice.js
+++ b/client/src/store/tableSlice.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-param-reassign */
+import { createSlice, PayloadAction, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "../common/axios";
+
+const name = "table";
+
+const initialState = {
+  isAddClick: false,
+  tables: [],
+};
+
+export const tableSlice = createSlice({
+  name,
+  initialState,
+  reducers: {
+    getTables: (state, action) => {
+      state.tables = [...action.payload];
+    },
+    add: (state, action) => {
+      state.isAddClick = action.payload; // 상태 변경 예시 1
+    },
+  },
+  extraReducers: {},
+});
+
+export const { getTables, add } = tableSlice.actions;

--- a/client/src/style/color.scss
+++ b/client/src/style/color.scss
@@ -7,6 +7,7 @@ $gray200: #eeeeee;
 $gray300: #e0e0e0;
 $gray400: #bdbdbd;
 $gray500: #9e9e9e;
+$gray600: #757575;
 $deepblue: #7878ff;
 $macDelete: #ed695e;
 $create: #61c454;

--- a/client/src/style/color.scss
+++ b/client/src/style/color.scss
@@ -9,6 +9,8 @@ $gray400: #bdbdbd;
 $gray500: #9e9e9e;
 $gray600: #757575;
 $deepblue: #7878ff;
+$macblue: #32abff;
+$macyellow: #fff42b;
 $macDelete: #ed695e;
 $create: #61c454;
 $darkmode: #292a2d;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1098,7 +1098,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.16.3", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.3.tgz#b86f0db02a04187a3c17caa77de69840165d42d5"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -1437,6 +1437,16 @@
     schema-utils "^2.6.5"
     source-map "^0.7.3"
 
+"@reduxjs/toolkit@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.2.tgz#2f2b5365df77dd6697da28fdf44f33501ed9ba37"
+  integrity sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==
+  dependencies:
+    immer "^9.0.6"
+    redux "^4.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@rollup/plugin-node-resolve@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-7.1.3.tgz#80de384edfbd7bfc9101164910f86078151a3eca"
@@ -1661,6 +1671,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -1720,10 +1738,34 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.1.tgz#374e31645d58cb18a07b3ecd8e9dede4deb2cccd"
   integrity sha512-DxZZbyMAM9GWEzXL+BMZROWz9oo6A9EilwwOMET2UVu2uZTqMWS5S69KVtuVKaRjCUpcrOXRalet86/OpG4kqw==
 
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
 "@types/q@^1.5.1":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
+
+"@types/react-redux@^7.1.20":
+  version "7.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.20.tgz#42f0e61ababb621e12c66c96dda94c58423bd7df"
+  integrity sha512-q42es4c8iIeTgcnB+yJgRTTzftv3eYYvCZOh1Ckn2eX/3o5TdsQYKUWpLoLuGlcY/p+VAhV9IOEZJcWk/vfkXw==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*":
+  version "17.0.37"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.37.tgz#6884d0aa402605935c397ae689deed115caad959"
+  integrity sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1731,6 +1773,11 @@
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -3820,6 +3867,11 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
+csstype@^3.0.2:
+  version "3.0.10"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.10.tgz#2ad3a7bed70f35b965707c092e5f30b327c290e5"
+  integrity sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -5645,6 +5697,13 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hoopy@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
@@ -5862,6 +5921,11 @@ immer@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+
+immer@^9.0.6:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.7.tgz#b6156bd7db55db7abc73fd2fdadf4e579a701075"
+  integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -9459,7 +9523,7 @@ react-icons@^4.3.1:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.3.1.tgz#2fa92aebbbc71f43d2db2ed1aed07361124e91ca"
   integrity sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==
 
-react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9468,6 +9532,23 @@ react-is@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-redux@^7.2.6:
+  version "7.2.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.6.tgz#49633a24fe552b5f9caf58feb8a138936ddfe9aa"
+  integrity sha512-10RPdsz0UUrRL1NZE0ejTkucnclYSgXp5q+tB5SWx2qeG2ZJQJyymgAhwKy73yiL/13btfB6fPr+rgbMAaZIAQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@types/react-redux" "^7.1.20"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.2"
 
 react-refresh@^0.8.3:
   version "0.8.3"
@@ -9652,6 +9733,18 @@ redent@^1.0.0:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
 
+redux-thunk@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
+  integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
+
+redux@^4.0.0, redux@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -9830,6 +9923,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What?
전체적인 사이트 구조 및 create table 기능
RUD는 왼쪽 사이드바에서 table 이름을 누르면 할 수 있도록 구현 예정.(다음 작업)

## Why?
필수 기능

## How?
명령어X UI로 테이블의 컬럼을 만들 때 필요한 것 구현

## Testing?
yes

## Screenshots (optional)
<img width="1792" alt="스크린샷 2021-12-05 오전 11 35 11" src="https://user-images.githubusercontent.com/62797441/144731360-70a1d5ba-0bee-4960-b123-b6aa3a294c0b.png">
전체적인 사이트 구조와 create table UI 입니다.

<img width="568" alt="스크린샷 2021-12-05 오전 11 34 23" src="https://user-images.githubusercontent.com/62797441/144731394-42ac4c93-92b9-41f4-bfcb-5dd097778828.png">
위 사진은 create table 할 때 보낼 데이터들입니다.
먼저, tableName이 있고 각각의 객체가 컬럼입니다.

컬럼의 데이터 형식은 다음과 같습니다.
```
{
    columnName: "" : 사용자 입력
    dataType: "CHAR", => 이슈에 있음(사용할 자료형 논의 필요)
    constraint: false or NOT NULL, UNIQUE
    default: "" : 사용자 입력
    PK: false or true
    FK: false or 현재 DB에 존재하는 테이블 이름,
}
```
만약 사용자가 PK true에 체크하면 FK와 constraint는 자동 false 됩니다.
이러한 형식의 컬럼 여러 개 + tableName이 합쳐진 형태의 데이터입니다.

이것들 참고하셔서 api 개발해주시면 감사하겠습니다.

## Anything Else?
#25 자료형 논의 필요


## Reviewers
@DongWooE 
@L-o-g-a-n 