### PR TITLE
스키마 인터페이스 구현

### DIFF
--- a/client/src/__mocks/SchemaMocks.js
+++ b/client/src/__mocks/SchemaMocks.js
@@ -1,0 +1,52 @@
+const schemaMocks = [
+  {
+    Field: "name",
+    Type: "varchar(20)",
+    Null: "NO",
+    key: "",
+    Default: null,
+    Extra: "",
+  },
+  {
+    Field: "courseId",
+    Type: "varchar(20)",
+    Null: "NO",
+    key: "PRI",
+    Default: null,
+    Extra: "",
+  },
+  {
+    Field: "description",
+    Type: "text",
+    Null: "YES",
+    key: "",
+    Default: null,
+    Extra: "",
+  },
+  {
+    Field: "createAt",
+    Type: "datetime",
+    Null: "NO",
+    key: "",
+    Default: null,
+    Extra: "",
+  },
+  {
+    Field: "updateAt",
+    Type: "datetime",
+    Null: "NO",
+    key: "",
+    Default: null,
+    Extra: "",
+  },
+  {
+    Field: "userId",
+    Type: "varchar(20)",
+    Null: "NO",
+    key: "FOR",
+    Default: null,
+    Extra: "",
+  },
+];
+
+export default schemaMocks;

--- a/client/src/components/AddTable/index.jsx
+++ b/client/src/components/AddTable/index.jsx
@@ -8,7 +8,24 @@ export default function AddTable() {
   const [columns, setColumns] = useState([]);
   const nextId = useRef(1);
 
+  const initialState = {
+    columnName: "",
+    dataType: "CHAR",
+    constraint: false,
+    default: "",
+    PK: false,
+    FK: false,
+  };
+
   let isNullColumnName = true;
+
+  useEffect(() => {
+    for (let i = 0; i < 3; i += 1) {
+      columns.push({ id: nextId.current, ...initialState });
+      nextId.current += 1;
+    }
+    setColumns([...columns]);
+  }, []);
 
   const removeColumn = remove => {
     setColumns(columns.filter(column => column.id !== remove));
@@ -23,16 +40,7 @@ export default function AddTable() {
       if (column.columnName.length !== 0) isNullColumnName = false;
     });
     if (tableName.length >= 1 && !isNullColumnName)
-      console.log({ tableName, ...columns });
-  };
-
-  const initialState = {
-    columnName: "",
-    dataType: "CHAR",
-    constraint: false,
-    default: "",
-    PK: false,
-    FK: false,
+      console.log({ tableName, ...columns }); // 데이터 전송 api 연결
   };
 
   return (

--- a/client/src/components/AddTable/style.scss
+++ b/client/src/components/AddTable/style.scss
@@ -22,7 +22,7 @@
     .addCircle {
       width: 20px;
       height: 20px;
-      background-color: $adding;
+      background-color: $macblue;
       border-radius: 50%;
       margin: auto 5px auto 0;
     }

--- a/client/src/components/DbCardList/DbCard/style.scss
+++ b/client/src/components/DbCardList/DbCard/style.scss
@@ -32,7 +32,7 @@
       background-color: $macDelete;
     }
     .add {
-      background-color: $adding;
+      background-color: $macblue;
     }
     .text {
       margin: auto 0;
@@ -65,8 +65,8 @@
     font-family: "Nanum Gothic", sans-serif;
     color: $black;
     &:focus {
-      outline: 3px solid $primary;
-      // border-radius: 7px;
+      outline: 3px solid $black;
+      border-radius: 4px;
     }
     &::placeholder {
       transform: translateY(-5px);

--- a/client/src/components/LoginForm/index.jsx
+++ b/client/src/components/LoginForm/index.jsx
@@ -95,7 +95,11 @@ export default function LoginForm() {
 
         <input className="submit" type="submit" value="로그인" />
       </form>
-      <img className="img" alt="Check Mate" src="" />
+      <img
+        className="img"
+        alt="Check Mate"
+        src="https://user-images.githubusercontent.com/62797441/145247515-e5027855-1073-4960-a832-6fba3db17772.png"
+      />
     </main>
   );
 }

--- a/client/src/components/LoginForm/style.scss
+++ b/client/src/components/LoginForm/style.scss
@@ -93,7 +93,7 @@
     }
   }
   .img {
-    width: 400px;
+    width: 200px;
     margin: 0 auto auto auto;
   }
 }

--- a/client/src/components/Navigation/index.jsx
+++ b/client/src/components/Navigation/index.jsx
@@ -3,20 +3,23 @@ import cx from "classnames";
 import "./style.scss";
 import { AiOutlineDatabase } from "react-icons/ai";
 import { useDispatch, useSelector } from "react-redux";
-import { add } from "../../store/tableSlice";
+import { setTable } from "../../store/tableSlice";
 
 export default function Natigation() {
+  const [isOnClick, setOnclick] = useState(false);
   const dispatch = useDispatch();
   const tables = useSelector(state => state.table.tables);
+  const currentTable = useSelector(state => state.table.currentTable);
 
-  console.log(tables);
   return (
     <nav className="navigation">
       <button
         type="button"
-        className="addTable"
+        className={cx("addTable", {
+          isFocus: currentTable === "createTable",
+        })}
         onClick={() => {
-          dispatch(add(true));
+          dispatch(setTable("createTable"));
         }}>
         <AiOutlineDatabase />
         <p className="addText">테이블 추가</p>
@@ -24,7 +27,15 @@ export default function Natigation() {
       <p className="naviTitle">테이블 목록</p>
       <ul className="sideMenu">
         {tables.map(table => (
-          <li key={table.id + table.title} className="tableTitle">
+          <li
+            key={table.id + table.title}
+            className={cx("tableTitle", {
+              isFocus: table.title === currentTable,
+            })}
+            onClick={() => {
+              dispatch(setTable(table.title));
+            }}
+            aria-hidden="true">
             {table.title}
           </li>
         ))}

--- a/client/src/components/Navigation/index.jsx
+++ b/client/src/components/Navigation/index.jsx
@@ -6,7 +6,6 @@ import { useDispatch, useSelector } from "react-redux";
 import { setTable } from "../../store/tableSlice";
 
 export default function Natigation() {
-  const [isOnClick, setOnclick] = useState(false);
   const dispatch = useDispatch();
   const tables = useSelector(state => state.table.tables);
   const currentTable = useSelector(state => state.table.currentTable);

--- a/client/src/components/Navigation/style.scss
+++ b/client/src/components/Navigation/style.scss
@@ -8,6 +8,7 @@
   background-color: $white;
   border-right: 1px solid $gray400;
   word-break: break-all;
+
   .addTable {
     display: flex;
     flex-direction: row;
@@ -20,7 +21,7 @@
     font-size: 26px;
     font-weight: bold;
     &:hover {
-      color: $create;
+      color: $primary;
     }
   }
   .naviTitle {
@@ -33,16 +34,20 @@
     display: flex;
     flex-direction: column;
     margin-bottom: 30px;
-    .tableTitle {
-      margin: 30px auto 0 30px;
-      color: $gray600;
-      font-size: 20px;
-      font-weight: 500;
-      &:hover {
-        color: $primary;
-        font-weight: bolder;
-        cursor: pointer;
-      }
+  }
+  .tableTitle {
+    margin: 30px auto 0 30px;
+    color: $gray600;
+    font-size: 20px;
+    font-weight: 500;
+    &:hover {
+      color: $primary;
+      font-weight: bolder;
+      cursor: pointer;
     }
+  }
+  .isFocus {
+    color: $primary;
+    font-weight: bolder;
   }
 }

--- a/client/src/components/Schema/index.jsx
+++ b/client/src/components/Schema/index.jsx
@@ -1,0 +1,43 @@
+import React, { useContext, useState, useEffect, useRef } from "react";
+import cx from "classnames";
+import "./style.scss";
+import schemaMocks from "../../__mocks/SchemaMocks";
+
+export default function Schema({ table }) {
+  useEffect(() => {}, [table]); // api 요청
+
+  return (
+    <div className="schemaContainer">
+      <p className="tableName">{table} 테이블</p>
+      <p className="schemaLabel">스키마 조회</p>
+      <ul>
+        {schemaMocks.map(attribute => (
+          <li key={attribute.Field}>
+            <form className="attribute">
+              <span className="attributeLabel"># {attribute.Field}</span>
+              <span className="attributeLabel">
+                {attribute.Type.toUpperCase()}
+              </span>
+              <span className="attributeLabel">
+                {attribute.Null === "NO" ? "NOT NULL" : "NULL 허용 "}
+              </span>
+              {attribute.Default && (
+                <span className="attributeLabel">
+                  DEFAULT: {attribute.Default}
+                </span>
+              )}
+              {attribute.key && (
+                <span className="attributeLabel">
+                  {attribute.key === "PRI" ? "PRIMARY KEY" : "FOREIGN KEY"}
+                </span>
+              )}
+              {attribute.Extra && (
+                <span className="attributeLabel">{attribute.Extra}</span>
+              )}
+            </form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/Schema/style.scss
+++ b/client/src/components/Schema/style.scss
@@ -1,0 +1,52 @@
+@import "../../style/color.scss";
+.schemaContainer {
+  display: flex;
+  flex-direction: column;
+  min-width: fit-content;
+  height: fit-content;
+  background-color: $white;
+  box-shadow: $box-shadow;
+  border-radius: 10px;
+  text-align: center;
+  margin: 200px auto;
+  padding: 20px;
+  font-weight: bold;
+  .tableName {
+    margin-bottom: 10px;
+    color: $darkmode;
+    font-size: 23px;
+  }
+  .schemaLabel {
+    font-size: 16px;
+    color: $darkmode;
+    margin-bottom: -5px;
+  }
+  .attribute {
+    width: fit-content;
+    display: flex;
+    flex-direction: row;
+    background-color: $primary;
+    border-radius: 4px;
+    padding: 5px;
+    margin-top: 15px;
+    .attributeLabel {
+      min-width: 120px;
+      width: fit-content;
+      margin: auto 20px auto 0;
+      text-align: left;
+      font-size: 16px;
+      &:first-child {
+        min-width: 160px;
+      }
+      &:nth-child(3) {
+        min-width: 77px;
+      }
+      &:nth-child(4) {
+        min-width: fit-content;
+      }
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+}

--- a/client/src/pages/InsideDataBase/index.jsx
+++ b/client/src/pages/InsideDataBase/index.jsx
@@ -26,7 +26,7 @@ export default function InsideDataBase(props) {
           <span>DB 조회</span>
         </div>
       </header>
-      <section className="buttonBar"></section>
+      {/* <section className="buttonBar"></section> */}
       <main className="mainContent">
         <Navigation />
         {currentTable === "createTable" ? (

--- a/client/src/pages/InsideDataBase/index.jsx
+++ b/client/src/pages/InsideDataBase/index.jsx
@@ -1,15 +1,18 @@
 import { useState, useEffect } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import "./style.scss";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { current } from "@reduxjs/toolkit";
 import Navigation from "../../components/Navigation";
 import AddTable from "../../components/AddTable";
 import TableMocks from "../../__mocks/TableMocks";
 import { getTables } from "../../store/tableSlice";
+import Schema from "../../components/Schema";
 
 export default function InsideDataBase(props) {
   const { dbName } = useParams();
   const dispatch = useDispatch();
+  const currentTable = useSelector(state => state.table.currentTable);
 
   useEffect(() => {
     dispatch(getTables(TableMocks));
@@ -20,13 +23,17 @@ export default function InsideDataBase(props) {
       <header className="titleBox">
         <div className="title">
           <span className="dbName">{dbName}</span>
-          <span>내부 조회</span>
+          <span>DB 조회</span>
         </div>
       </header>
       <section className="buttonBar"></section>
       <main className="mainContent">
         <Navigation />
-        <AddTable />
+        {currentTable === "createTable" ? (
+          <AddTable />
+        ) : (
+          <Schema table={currentTable} />
+        )}
       </main>
     </div>
   );

--- a/client/src/pages/InsideDataBase/style.scss
+++ b/client/src/pages/InsideDataBase/style.scss
@@ -6,7 +6,7 @@
   .titleBox {
     display: flex;
     flex-direction: column;
-    height: 100px;
+    height: 120px;
     background-color: $white;
     border-bottom: 1px solid $gray400;
     font-size: 40px;

--- a/client/src/store/tableSlice.js
+++ b/client/src/store/tableSlice.js
@@ -5,8 +5,8 @@ import axios from "../common/axios";
 const name = "table";
 
 const initialState = {
-  isAddClick: false,
   tables: [],
+  currentTable: "createTable",
 };
 
 export const tableSlice = createSlice({
@@ -16,11 +16,11 @@ export const tableSlice = createSlice({
     getTables: (state, action) => {
       state.tables = [...action.payload];
     },
-    add: (state, action) => {
-      state.isAddClick = action.payload; // 상태 변경 예시 1
+    setTable: (state, action) => {
+      state.currentTable = action.payload;
     },
   },
   extraReducers: {},
 });
 
-export const { getTables, add } = tableSlice.actions;
+export const { getTables, setTable } = tableSlice.actions;

--- a/client/src/store/tableSlice.js
+++ b/client/src/store/tableSlice.js
@@ -15,6 +15,7 @@ export const tableSlice = createSlice({
   reducers: {
     getTables: (state, action) => {
       state.tables = [...action.payload];
+      state.currentTable = "createTable";
     },
     setTable: (state, action) => {
       state.currentTable = action.payload;


### PR DESCRIPTION
## What?
테이블 별 스키마를 화면에 표시하기 위한 인터페이스 구현

## Why?
테이블 별 스키마를 보여줘야 합니다!

## How?
왼쪽 사이드바를 클릭하면 redux 상태 변화 -> 해당 메뉴의 테이블에 대한 스키마 정보 api 요청하여 데이터를 불러오고 화면에 표시한다.

## Testing?
목업 데이터로는 테스팅을 완료하였고 추후 api와 연동하여 진행할 예정입니다.

## Screenshots (optional)
<img width="713" alt="스크린샷 2021-12-09 오후 8 29 00" src="https://user-images.githubusercontent.com/62797441/145389141-54926fef-b326-433e-8ac1-805e717fd030.png">

## Anything Else?
![desc](https://user-images.githubusercontent.com/62797441/145389291-197db280-3ac9-4cb6-892f-78f31cace05c.png)
@DongWooE 님께서 주신 사진을 바탕으로 목업 데이터를 만들어 테스팅했습니다. 자세한 내용은 `SchemaMocks.js`파일을 확인해주시면 됩니다.

## Reviewers
@DongWooE 
@L-o-g-a-n 