### PR TITLE
[FIX] (#51) - Change using cookies into using headers

### DIFF
--- a/server/api/routes/v1/admin/controller.js
+++ b/server/api/routes/v1/admin/controller.js
@@ -45,10 +45,10 @@ const login = async(req,res,next) => {
     }
 
     const accessToken = await jwt.sign({uid: user.id}, JWT_SECRET_KEY_FILE, {algorithm: 'HS512', expiresIn: '1h'});  //accessToken 생성 
-    res.cookie('refreshToken', refreshToken, {httpOnly: true}); //refreshToken은 secure, httpOnly 옵션을 가진 쿠키로 보내 CSRF 공격을 방어
-    res.cookie('accessToken', accessToken, {httpOnly: true}); //accessToken은 secure, httpOnly 옵션을 가진 쿠키로 보내 CSRF 공격을 방어
+    //res.cookie('refreshToken', refreshToken, {httpOnly: true}); //refreshToken은 secure, httpOnly 옵션을 가진 쿠키로 보내 CSRF 공격을 방어
+    //res.cookie('accessToken', accessToken, {httpOnly: true}); //accessToken은 secure, httpOnly 옵션을 가진 쿠키로 보내 CSRF 공격을 방어
     //원래는 accessToken은 authorization header에 보내주는 게 보안상 좋지만, MVP 모델에서는 간소화
-    return res.json(createResponse(res, user)); 
+    return res.json(createResponse(res, {accessToken, refreshToken})); 
   } catch (error) {
     console.error(error);
     next(error);
@@ -98,9 +98,9 @@ const test = async(req,res,next) => { //토큰 잘 사용되는지 확인해보�
   try {
     console.log("성 공 적");
     console.log("이것은 Access");
-    console.log(req.cookies.accessToken);
+    console.log(req.headers.authorization.split('Bearer ')[1]);
     console.log("이것은 Refresh");
-    console.log(req.cookies.refreshToken);
+    console.log(req.headers.refresh);
     return res.json(createResponse(res, "성공했습니다."));
   } catch (error) {
     console.error(error);

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -4,21 +4,23 @@ const { LOGIN_REQUIRED, TOKEN_EXPIRED, JSON_WEB_TOKEN_ERROR } = require('../erro
 const fs = require('fs');
 const { join } = require('path');
 const { verifyToken } = require('../utils/jwt');
-const { RefreshToken, User } = require('../models');
+const { RefreshToken, Admin } = require('../models');
 
 const checkTokens = async(req,res,next) => {
   // const JWT_SECRET_KEY = fs.readFileSync(join(__dirname, '../keys/', JWT_SECRET_KEY_FILE));
   try {
-    if(req.cookies.accessToken == undefined) return next(LOGIN_REQUIRED);
-    const accessToken = verifyToken(req.cookies.accessToken); 
-    const refreshToken = verifyToken(req.cookies.refreshToken);
+    if(req.headers.authorization.split('Bearer ')[1] == undefined) return next(LOGIN_REQUIRED);
+    // const accessToken = verifyToken(req.cookies.accessToken); 
+    // const refreshToken = verifyToken(req.cookies.refreshToken);
+    const accessToken = verifyToken(req.headers.authorization.split('Bearer ')[1]);
+    const refreshToken = verifyToken(req.headers.refresh);
 
     if(accessToken == null) { 
       if(refreshToken == null)  //accessToken, refreshToken 모두 만료된 경우, 다시 로그인 하도록 요구
         return next(LOGIN_REQUIRED);
       else {  //accessToken은 만료되었지만 refreshToken은 유효한 경우
         const refresh = await RefreshToken.findOne({where: {refreshToken: req.cookies.refreshToken}});
-        const user = await refresh.getUser();
+        const user = await refresh.getAdmin();
         const newAccessToken = await jwt.sign({uid: user.id}, JWT_SECRET_KEY_FILE, {algorithm: 'HS512', expiresIn: '1h'});
         res.cookie('accessToken', newAccessToken, {httpOnly: true});
         req.cookies.accessToken = newAccessToken; //당장 다음 미들웨어에서 써야되기 때문에 처리해주는 듯 싶다.
@@ -28,7 +30,7 @@ const checkTokens = async(req,res,next) => {
     else {
       if(refreshToken == null) {  //accessToken은 유효하지만, refreshToken은 만료된 경우
         const newRefreshToken = await jwt.sign({}, JWT_SECRET_KEY_FILE, {algorithm: 'HS512', expiresIn: '14d'});  //refreshToken은 DB에 저장
-        const user = await User.findByPk(accessToken.uid);
+        const user = await Admin.findByPk(accessToken.uid);
         const refresh = await user.getRefreshToken();
         refresh.update({refreshToken: newRefreshToken});
         res.cookie('refreshToken', newRefreshToken, {httpOnly: true});


### PR DESCRIPTION
## What?
클라이언트 단에서 쿠키 방식으로 보내오던 토큰을 헤더에 담아서 보내오는 것으로 변경
그리고 로그인 시, 서버는 클라이언트에게 response로 토큰을 보냄.

## Why?
클라이언트 요청 및 보안 사항

## How?
req.headers를 사용

## Testing?
Postman으로 테스팅 완료

## Screenshots (optional)
<img width="768" alt="스크린샷 2021-12-23 오전 12 01 53" src="https://user-images.githubusercontent.com/77658361/147115154-83629565-d821-40e8-8834-491550f3389c.png">
클라이이언트는 위와같이 헤더에 토큰을 담아서 보내야합니다.


<img width="897" alt="스크린샷 2021-12-23 오전 12 03 01" src="https://user-images.githubusercontent.com/77658361/147115230-c123184c-b26e-4949-af5b-b15639319cfa.png">
로그인 시, 서버는 클라이언트에게 위와같이 토큰을 response로 보내줍니다.

## Anything Else?
X 


## Reviewers
@DongWooE 
@kingyong9169 