### PR TITLE
[FIX] - fix descTableAndGetPKs error

### DIFF
--- a/server/api/routes/v1/row/controller.js
+++ b/server/api/routes/v1/row/controller.js
@@ -146,15 +146,15 @@ const descTableAndGetPks = async(req,res,next)=>{
   const {name} = req.body;  
   try {
       const q = `DESC ${name}`;
-      let fks = [];
-      let doc = await poolQuery(q);
-      doc = await doc[0].map(item=>{
+      const fks = [];
+      let columns = await poolQuery(q);
+      columns = await columns[0].map(item => {
         if(item.Key == "MUL") fks.push(item.Field);
-        delete item.Extra
+        delete item.Extra;
         return item;
       });
-      let rows = await getPKs({"members":fks});
-      return res.json(createResponse(res,{"PKs":rows,"columns":doc}))
+      const PKs = await getPKs({ [`${name}`]: fks });
+      return res.json(createResponse(res, { PKs, columns}));
   } catch (error) {
       console.error(error);
       next(error);
@@ -162,36 +162,36 @@ const descTableAndGetPks = async(req,res,next)=>{
 }
 
 const getPKs = (body) => {
-  return new Promise(async(resolve,reject) =>{
-  try {
-    const tables = await descTable(body.name);
+  return new Promise(
+    async(resolve,reject) => {
+      try {
+        const PKs = {};
+        for(const FK of Object.values(body)[0]) {
+          const referencedTable = await poolQuery(`SELECT referenced_table_name FROM information_schema.key_column_usage WHERE table_name = '${Object.keys(body)[0]}' AND table_schema = '${MYSQL_DATABASE}' and column_name = '${FK}';`);
+          // const temp = {};
+          const tempArr = [];
+          if(referencedTable[0].length === 0)
+            return reject(TABLE_NOT_EXISTED);
 
-    let PKs = [];
-    for(const FK of Object.values(body)[0]) {
-      let referencedTable = await poolQuery(`SELECT referenced_table_name FROM information_schema.key_column_usage WHERE table_name = '${Object.keys(body)[0]}' AND table_schema = '${MYSQL_DATABASE}' and column_name = '${FK}';`);
-      let temp = {};
-      let tempArr = [];
-      if(referencedTable[0].length == 0)
-         return reject(TABLE_NOT_EXISTED);
-      
-      let columnsPK = await poolQuery(`SELECT column_name FROM Information_schema.columns
-      WHERE table_schema = '${MYSQL_DATABASE}' AND table_name = '${referencedTable[0][0].referenced_table_name}' AND column_key = 'PRI';
-      `);
+          const columnsPK = await poolQuery(`SELECT column_name FROM Information_schema.columns
+          WHERE table_schema = '${MYSQL_DATABASE}' AND table_name = '${referencedTable[0][0].referenced_table_name}' AND column_key = 'PRI';
+          `);
 
-      let values = await poolQuery(`SELECT ${Object.values(columnsPK[0][0])} FROM ${referencedTable[0][0].referenced_table_name};`);
+          const values = await poolQuery(`SELECT ${Object.values(columnsPK[0][0])} FROM ${referencedTable[0][0].referenced_table_name};`);
 
-      for(const i of values[0]) {
-        tempArr.push(Object.values(i)[0]);
+          for(const i of values[0]) {
+            tempArr.push(Object.values(i)[0]);
+          }
+          // temp[`${Object.values(columnsPK[0][0])}`] = tempArr;
+          // PKs.push(temp);
+          PKs[`${FK}`] = tempArr;
+        }
+        return resolve(PKs);
+      } catch (error) {
+        console.error(error);
+        return reject(error);
       }
-      temp[`${Object.values(columnsPK[0][0])}`] = tempArr;
-      PKs.push(temp);        
-    }
-    return resolve(PKs);
-  } catch (error) {
-    console.error(error);
-    return reject(error);
-    }
-  })
-};
+  });
+}
 
 module.exports = {showRows, createRows, updateRows, deleteRow, descTableAndGetPks};


### PR DESCRIPTION
## What?
descTableAndGetPKs 라우터 에러 수정

## Why?
``` js
const PKs = await getPKs({ "members": fks }); // 이전

const PKs = await getPKs({ [`${name}`]: fks }); // 이후
```
1. 이전 코드에서 members 에만 국한되어 있기 때문에 다른 table의 데이터를 정상적으로 가져올 수 없음


2. 또한, 반환되는 데이터 형태 변경

이전
``` js
[
    { courseDatePK: [...] },
    { id: [...] },
    { userId: [...] }
]
```

이후
``` js
{
    courseDatePK: [...],
    memberlistsId: [...],
    userId: [...]
}
```
<img width="603" alt="스크린샷 2022-01-01 오후 11 16 06" src="https://user-images.githubusercontent.com/62797441/147852585-6038761e-ed73-4b83-a1d3-727b11ff01b8.png">

3. 또한, 실제 부모 테이블의 컬럼명은 id인데 자식 테이블에서는 memberlistsId로 사용하여 클라이언트에서 데이터를 사용하는데 차질이 있음.
이 부분은 
``` js
PKs[`${FK}`] = tempArr;
```
로 간단히 해결

## How?


## Testing?
O

## Screenshots (optional)
X


## Anything Else?
X 


## Reviewers
@DongWooE 
@L-o-g-a-n 