### PR TITLE
[Feat] 데이터 입력시 FK선택 인터페이스

### DIFF
--- a/client/src/components/DataCardList/DataCard/index.jsx
+++ b/client/src/components/DataCardList/DataCard/index.jsx
@@ -7,7 +7,9 @@ import { searchKeyPK } from "../../../utils";
 import "./style.scss";
 
 export default function DataCard({ isNew, data, clientId, add, remove }) {
-  const currentSchemaData = useSelector(state => state.table.currentSchemaData);
+  const { currentSchemaData, currentSchemaPKs } = useSelector(
+    state => state.table,
+  );
   const { attributes, schemaKey } = currentSchemaData;
   const [msgState, setMsgState] = useState("");
   const [isAddClick, setIsAddClick] = useState(false);
@@ -23,6 +25,10 @@ export default function DataCard({ isNew, data, clientId, add, remove }) {
     }
     if (isAddClick && isNew) setMsgState("추가 중");
   }, [isNew, isAddClick]);
+
+  const fkSelect = (e, attribute) => {
+    data[attribute] = e.target.value;
+  };
 
   return (
     <div className="dataCard">
@@ -46,7 +52,26 @@ export default function DataCard({ isNew, data, clientId, add, remove }) {
               {Object.keys(attributes).map((attribute, index) => {
                 if (attribute === "createdAt" || attribute === "updatedAt")
                   return;
-
+                if (currentSchemaPKs[attribute])
+                  return (
+                    <tr key={attribute + attribute.length}>
+                      <td className="attribute column">{attribute}</td>
+                      <td className="attribute">
+                        <select
+                          className="select"
+                          name="fk"
+                          defaultValue=""
+                          onChange={e => fkSelect(e, attribute)}>
+                          <option value="">입력X</option>
+                          {currentSchemaPKs[attribute].map(FK => (
+                            <option key={FK + attribute} value={`${FK}`}>
+                              {FK}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                    </tr>
+                  );
                 return (
                   <tr key={attribute + attribute.length}>
                     <td className="attribute column">{attribute}</td>

--- a/client/src/components/DataCardList/DataCard/style.scss
+++ b/client/src/components/DataCardList/DataCard/style.scss
@@ -60,9 +60,10 @@
       padding: 5px;
       font-size: 18px;
       word-break: break-all;
+      .select,
       .input {
         line-height: 19px;
-        border: none;
+        border: 1px solid $gray400;
         border-radius: 6px;
         color: $darkmode;
         font-size: 18px;
@@ -75,6 +76,9 @@
         &::-ms-input-placeholder {
           font-size: 13px;
         }
+      }
+      .input {
+        border: none;
       }
     }
     .column {

--- a/client/src/components/DataCardList/index.jsx
+++ b/client/src/components/DataCardList/index.jsx
@@ -14,7 +14,9 @@ export default function DataCardList() {
   const [message, setMessage] = useState("");
   const dispatch = useDispatch();
   const nextId = useRef(0);
-  const { currentTable, currentSchemaData } = useSelector(state => state.table);
+  const { currentTable, currentSchemaData, currentSchemaPKs } = useSelector(
+    state => state.table,
+  );
   const { isLoading, errorMessage, currentDataList } = useSelector(
     state => state.data,
   );
@@ -48,10 +50,18 @@ export default function DataCardList() {
   }, [reload]);
 
   const addNewData = data => {
+    const emptyFKs = [];
+    Object.keys(data).forEach(attribute => {
+      if (currentSchemaPKs[attribute] && !data[attribute])
+        emptyFKs.push(attribute);
+    });
     dispatch(
       addData({
         tableName: currentTable,
-        rows: deleteKey([data], ["clientId", "createdAt", "updatedAt"]),
+        rows: deleteKey(
+          [data],
+          ["clientId", "createdAt", "updatedAt", ...emptyFKs],
+        ),
       }),
     )
       .unwrap()
@@ -90,7 +100,10 @@ export default function DataCardList() {
     setDataList([...dataList, { clientId: nextId.current, ...attributes }]);
   };
 
-  return !isLoading && attributes && !reload ? (
+  return !isLoading &&
+    attributes &&
+    !reload &&
+    schemaKey.FK.length === Object.keys(currentSchemaPKs).length ? (
     <>
       <h2 className="dataListTitle">{currentTable} 테이블의 데이터 목록</h2>
       {message === "" ? (

--- a/client/src/components/MainContainer/index.jsx
+++ b/client/src/components/MainContainer/index.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect, useRef } from "react";
 import cx from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import SchemaMocks from "../../__mocks/SchemaMocks";
-import { getPKs, getSchema } from "../../store/tableSlice";
+import { getSchemaPKs } from "../../store/tableSlice";
 import Loading from "../Loading";
 import Error from "../Error";
 import Schema from "../Schema";
@@ -16,11 +16,10 @@ export default function MainContainer() {
   const { isLoading, errorMessage, currentTable } = useSelector(
     state => state.table,
   );
-  const { schemaKey } = useSelector(state => state.table.currentSchemaData);
 
   useEffect(() => {
     setMenuSelect("schema");
-    dispatch(getSchema(currentTable))
+    dispatch(getSchemaPKs(currentTable))
       .unwrap()
       .then(() => {
         setMessage("");
@@ -29,13 +28,6 @@ export default function MainContainer() {
         setMessage("스키마 불러오기에 실패했습니다.");
       });
   }, [currentTable]);
-
-  useEffect(() => {
-    if (schemaKey) {
-      console.log({ [currentTable]: schemaKey.FK });
-      // dispatch(getPKs({ [currentTable]: schemaKey.FK }));
-    }
-  }, [schemaKey]);
 
   if (!isLoading && message === "")
     return (

--- a/client/src/components/Schema/index.jsx
+++ b/client/src/components/Schema/index.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
 import cx from "classnames";
 import { useSelector, useDispatch } from "react-redux";
-import { removeTable, getSchema } from "../../store/tableSlice";
+import { removeTable } from "../../store/tableSlice";
 import Loading from "../Loading";
 import Error from "../Error";
 import "./style.scss";

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -12,7 +12,7 @@ export const store = configureStore({
   },
   middleware: getDefaultMiddleware =>
     getDefaultMiddleware({
-      serializableCheck: false,
+      // serializableCheck: false,
     }).concat(logger),
   // devTools: process.env.NODE_ENV !== "production",
 });


### PR DESCRIPTION
## What?
FK 값을 입력할 때, 아무 값을 입력하는 것을 방지하여 select, option 태그를 이용해 사용자가 기존 FK에 해당하는 값을 선택할 수 있도록 구현.

## Why?
referenced 테이블의 PK에 해당하는 값들 => `A`라고 칭하겠습니다.

FK 값을 입력하는 것은 다른 테이블을 참조한다는 뜻으로, 데이터를 입력할 때, `A`중 하나만 넣어야 하기 때문에 사용자에게 `A`에 어떤 값들이 있는지 알려주고 이를 선택하도록 하기 위함.

## How?
schema 데이터를 받아올 때, `A`를 모두 불러온다.
불러온 데이터를 redux에 저장하고 사용자가 `데이터 추가`를 누르면 해당 인터페이스가 나타난다.
만약 `A`가 없으면 `입력X`만 선택가능
있으면 `입력X, 해당 값들..`을 선택할 수 있다.
여기서 `입력X`를 넣어준 이유는 FK값을 컬럼으로 가질 때, null로 허용하는 테이블도 있기 때문.
=> 사용자가 `입력X`선택 시 해당 FK 속성을 제외하고 서버에 데이터를 보내줍니다.

## Testing?
O, 현재는 모두 정상 작동 나중에 버그 발생 시 수정

## Screenshots (optional)
![selectFK](https://user-images.githubusercontent.com/62797441/148058838-e6685282-1495-4a6e-8c41-23a0c10e4f91.gif)

## Anything Else?
X 


## Reviewers
@DongWooE 
@L-o-g-a-n 